### PR TITLE
fix filter field in content search

### DIFF
--- a/Freesound.sc
+++ b/Freesound.sc
@@ -211,9 +211,9 @@ FSSound : FSObj{
 		FSReq.new(Freesound.uri(\TEXT_SEARCH),params).get(action,FSPager);
 	}
 
-	*contentSearch{|target, filter, params, action|
+	*contentSearch{|target, descriptorsFilter, params, action|
 		params = FSSound.initParams(params);
-		params.putAll(('target' : target, 'filter' : filter));
+		params.putAll(('target' : target, 'descriptors_filter' : descriptorsFilter));
 		FSReq.new(Freesound.uri(\CONTENT_SEARCH), params).get(action,FSPager);
 	}
 

--- a/HelpSource/Freesound.schelp
+++ b/HelpSource/Freesound.schelp
@@ -123,7 +123,7 @@ FSSound.textSearch( query: "glitch", filter: "type:wav",params:('page':2), actio
 
 FSSound.contentSearch(
 	target: '.lowlevel.pitch.mean:600',
-	filter: '.lowlevel.pitch_instantaneous_confidence.mean:[0.8 TO 1]',
+	descriptorsFilter: '.lowlevel.pitch_instantaneous_confidence.mean:[0.8 TO 1]',
 	params: ('page':2), action: {|pager|
 		    ~snd = pager[0];
 		    ~snd.name.postln;


### PR DESCRIPTION
The name of the filter field/parameter for the content search is "descriptors_filter" and not "filter" (refer [here](https://freesound.org/docs/api/resources_apiv2.html#search-resources) for more). Currently entering values in this field does not do anything, i.e. the filter does not work but no error is raised. With this fix, the field works as expected.